### PR TITLE
Fixed a bug where the X and Y coordinates were mixed up inside of draw_iter()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ where
     {
         for Pixel(pos, color) in pixels {
             if let Some(mapped_pos) = M::map(pos) {
-                self.content.0[mapped_pos.x as usize][mapped_pos.y as usize] =
+                self.content.0[mapped_pos.y as usize][mapped_pos.x as usize] =
                     RGB8::new(color.r(), color.g(), color.b());
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
         matrix.flush().unwrap();
 
         for i in 0..64 {
-            if i == 7 {
+            if i == 56 {
                 assert_eq!(
                     content[i],
                     RGB8::new(255, 255, 255),


### PR DESCRIPTION
This corrects the `self.content.0` X and Y indexes inside of `draw_iter()`.  Since your examples have the same X and Y dimensions I understand how this was missed :smile: but *man* did it give me trouble trying to troubleshoot! haha