### PR TITLE
Updated embedded-hal dependency to 0.2.7 and added flush_with_gamma() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ exclude = [
 [dependencies]
 display-interface = "0.4.1"
 embedded-graphics-core = "0.3.3"
-embedded-hal = "0.2.6"
+embedded-hal = "0.2.7"
 smart-leds = "0.3.0"
 smart-leds-trait = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use embedded_graphics_core::{
     Pixel,
 };
 
-use smart_leds::{brightness, hsv::RGB8, SmartLedsWrite};
+use smart_leds::{brightness, gamma, hsv::RGB8, SmartLedsWrite};
 
 pub mod layout;
 use layout::Layout;
@@ -56,6 +56,12 @@ where
 
     pub fn flush(&mut self) -> Result<(), T::Error> {
         let iter = brightness(self.content.as_slice().iter().cloned(), self.brightness);
+        self.writer.write(iter)
+    }
+    pub fn flush_with_gamma(&mut self) -> Result<(), T::Error> {
+        let iter = brightness(gamma(
+            self.content.as_slice().iter().cloned()
+        ), self.brightness);
         self.writer.write(iter)
     }
 }


### PR DESCRIPTION
Firstly, I updated the `embedded-hal` dependency in `Cargo.toml` to the latest & greatest (0.2.7) because...  Let's stay up-to-date, yeah? :smile: (I tested it and there's no issues)

Also, there was no way to use `smart-leds` built-in gamma correction feature with `smart-leds-matrix` because of how it works so I added an additional method to `impl<T: SmartLedsWrite, M: Transformation<W, H> ...`, `flush_with_gamma()` that applies the `gamma()` correction in addition to the usual `brightness()`