### PR TITLE
Bumped embedded-graphics-core to v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 
 [dependencies]
 display-interface = "0.4.1"
-embedded-graphics-core = "0.3.3"
+embedded-graphics-core = "0.4.0"
 embedded-hal = "0.2.7"
 smart-leds = "0.3.0"
 smart-leds-trait = "0.2.1"


### PR DESCRIPTION
Due to this causing issues, when working on more recent versions of embedded-graphics, a bump only makes sense.